### PR TITLE
Changes for authorizer lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,19 @@ cd ../..
 
 ### 3. Deploy the CDK stack
 
+#### Option 1: API Key Authentication (Default)
 ```bash
 cdk bootstrap  # Only needed the first time you use CDK in an account/region
 cdk deploy
 ```
 
-The deployment will output the GraphQL API URL and API Key that you can use to interact with your API.
+#### Option 2: Lambda Authorization
+```bash
+cdk bootstrap  # Only needed the first time you use CDK in an account/region
+cdk deploy -c useLambdaAuth=true
+```
+
+The deployment will output the GraphQL API URL and either an API Key or authorization type based on your choice.
 
 ## Testing the API
 
@@ -115,8 +122,14 @@ You can test the API using the AWS AppSync Console or any GraphQL client like [P
 
 You can test your API using popular API clients like Thunder Client or Postman:
 
+#### For API Key Authentication:
 1. **Configure your request headers:**
    - `x-api-key`: Your AppSync API key
+   - `Content-Type`: application/json
+
+#### For Lambda Authorization:
+1. **Configure your request headers:**
+   - `Authorization`: Bearer valid-token (or Bearer admin-token)
    - `Content-Type`: application/json
 
 2. **Set the endpoint URL** to your AppSync API URL
@@ -170,6 +183,21 @@ mutation CreateTodo {
   }
 }
 ```
+
+## Authorization Options
+
+This project supports two authentication methods:
+
+### API Key Authentication (Default)
+- Simple API key-based authentication
+- Suitable for development and testing
+- Use `x-api-key` header with requests
+
+### Lambda Authorization
+- Custom Lambda function validates requests
+- Supports Bearer token authentication
+- Deploy with `-c useLambdaAuth=true`
+- Test tokens: `valid-token` or `admin-token`
 
 ## Security
 

--- a/src/TodoApp.Api/AuthorizerFunction.cs
+++ b/src/TodoApp.Api/AuthorizerFunction.cs
@@ -19,16 +19,14 @@ public class AuthorizerFunction
             var apiId = appSyncAuthorizerEvent.RequestContext.ApiId;
             var accountId = appSyncAuthorizerEvent.RequestContext.AccountId;
             
-            if (string.IsNullOrEmpty(authorizationToken) || !authorizationToken.StartsWith("Bearer "))
+            if (string.IsNullOrEmpty(authorizationToken))
             {
-                context.Logger.LogError("Invalid token format");
+                context.Logger.LogError("Missing authorization token");
                 return Task.FromResult(new AppSyncAuthorizerResult { IsAuthorized = false });
             }
-
-            var actualToken = authorizationToken.Substring("Bearer ".Length);
             
             // Simple validation
-            var isAuthorized = actualToken == "valid-token" || actualToken == "admin-token";
+            var isAuthorized = authorizationToken == "valid-token" || authorizationToken == "admin-token";
             context.Logger.LogInformation($"Authorization result: {isAuthorized}");
             
             return Task.FromResult(new AppSyncAuthorizerResult
@@ -37,7 +35,7 @@ public class AuthorizerFunction
                 ResolverContext = new Dictionary<string, string>
                 {
                     { "userId", "user123" },
-                    { "role", actualToken == "admin-token" ? "admin" : "user" },
+                    { "role", authorizationToken == "admin-token" ? "admin" : "user" },
                     { "apiId", apiId },
                     { "accountId", accountId }
                 },

--- a/src/TodoApp.Api/AuthorizerFunction.cs
+++ b/src/TodoApp.Api/AuthorizerFunction.cs
@@ -1,0 +1,56 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.Annotations;
+using System.Text.Json;
+
+namespace TodoApp.Api;
+
+public class AuthorizerFunction
+{
+    [LambdaFunction]
+    public Dictionary<string, object> Authorize(Dictionary<string, object> request, ILambdaContext context)
+    {
+        context.Logger.LogInformation($"Authorization request: {JsonSerializer.Serialize(request)}");
+
+        try
+        {
+            // Get the authorization token from the request
+            if (!request.TryGetValue("authorizationToken", out var tokenObj))
+            {
+                context.Logger.LogError("No authorizationToken found");
+                return new Dictionary<string, object> { { "isAuthorized", false } };
+            }
+
+            var token = tokenObj?.ToString() ?? "";
+            context.Logger.LogInformation($"Token: {token}");
+            
+            if (string.IsNullOrEmpty(token) || !token.StartsWith("Bearer "))
+            {
+                context.Logger.LogError("Invalid token format");
+                return new Dictionary<string, object> { { "isAuthorized", false } };
+            }
+
+            var actualToken = token.Substring("Bearer ".Length);
+            context.Logger.LogInformation($"Actual token: {actualToken}");
+            
+            // Simple validation
+            var isAuthorized = actualToken == "valid-token" || actualToken == "admin-token";
+            context.Logger.LogInformation($"Is authorized: {isAuthorized}");
+            
+            return new Dictionary<string, object>
+            {
+                { "isAuthorized", isAuthorized },
+                { "resolverContext", new Dictionary<string, object>
+                    {
+                        { "userId", "user123" },
+                        { "role", actualToken == "admin-token" ? "admin" : "user" }
+                    }
+                }
+            };
+        }
+        catch (Exception ex)
+        {
+            context.Logger.LogError($"Error: {ex.Message}");
+            return new Dictionary<string, object> { { "isAuthorized", false } };
+        }
+    }
+}

--- a/src/TodoApp.Api/Functions.cs
+++ b/src/TodoApp.Api/Functions.cs
@@ -51,8 +51,17 @@ namespace TodoApp.Api
         [Logging(LogEvent = true)]
         public async Task<Todo> DeleteTodoItem(AppSyncResolverEvent<Dictionary<string, string>> appSyncEvent)
         {
-            // Check if user has admin role
-            var role = appSyncEvent.RequestContext.Identity.Claims["role"];
+            // Get role from resolver context passed by authorizer
+            var role = "user"; // default role
+            if (appSyncEvent.Identity != null)
+            {
+                var identity = appSyncEvent.Identity as Dictionary<string, object>;
+                if (identity?.ContainsKey("role") == true)
+                {
+                    role = identity["role"]?.ToString() ?? "user";
+                }
+            }
+            
             if (role != "admin")
             {
                 throw new UnauthorizedAccessException("Only admins can delete todos");

--- a/src/TodoApp.Api/Functions.cs
+++ b/src/TodoApp.Api/Functions.cs
@@ -51,8 +51,14 @@ namespace TodoApp.Api
         [Logging(LogEvent = true)]
         public async Task<Todo> DeleteTodoItem(AppSyncResolverEvent<Dictionary<string, string>> appSyncEvent)
         {
-            var id = appSyncEvent.Arguments["id"].ToString();
+            // Check if user has admin role
+            var role = appSyncEvent.RequestContext.Identity.Claims["role"];
+            if (role != "admin")
+            {
+                throw new UnauthorizedAccessException("Only admins can delete todos");
+            }
 
+            var id = appSyncEvent.Arguments["id"].ToString();
             return await _todoService.DeleteTodoItem(id);
         }
     }

--- a/src/TodoApp.Api/serverless.template
+++ b/src/TodoApp.Api/serverless.template
@@ -88,7 +88,7 @@
         "Handler": "TodoApp.Api::TodoApp.Api.Functions_DeleteTodoItem_Generated::DeleteTodoItem"
       }
     },
-    "TodoAppApiAuthorizerFunctionAuthorizeGenerated": {
+    "TodoAppApiAuthorizerFunctionCustomLambdaAuthorizerHandlerGenerated": {
       "Type": "AWS::Serverless::Function",
       "Metadata": {
         "Tool": "Amazon.Lambda.Annotations"
@@ -102,7 +102,7 @@
           "AWSLambdaBasicExecutionRole"
         ],
         "PackageType": "Zip",
-        "Handler": "TodoApp.Api::TodoApp.Api.AuthorizerFunction_Authorize_Generated::Authorize"
+        "Handler": "TodoApp.Api::TodoApp.Api.AuthorizerFunction_CustomLambdaAuthorizerHandler_Generated::CustomLambdaAuthorizerHandler"
       }
     }
   }

--- a/src/TodoApp.Api/serverless.template
+++ b/src/TodoApp.Api/serverless.template
@@ -11,7 +11,7 @@
       "Properties": {
         "Runtime": "dotnet8",
         "CodeUri": ".",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
@@ -28,7 +28,7 @@
       "Properties": {
         "Runtime": "dotnet8",
         "CodeUri": ".",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
@@ -45,7 +45,7 @@
       "Properties": {
         "Runtime": "dotnet8",
         "CodeUri": ".",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
@@ -62,7 +62,7 @@
       "Properties": {
         "Runtime": "dotnet8",
         "CodeUri": ".",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
@@ -79,13 +79,30 @@
       "Properties": {
         "Runtime": "dotnet8",
         "CodeUri": ".",
-        "MemorySize": 256,
+        "MemorySize": 512,
         "Timeout": 30,
         "Policies": [
           "AWSLambdaBasicExecutionRole"
         ],
         "PackageType": "Zip",
         "Handler": "TodoApp.Api::TodoApp.Api.Functions_DeleteTodoItem_Generated::DeleteTodoItem"
+      }
+    },
+    "TodoAppApiAuthorizerFunctionAuthorizeGenerated": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
+      "Properties": {
+        "Runtime": "dotnet8",
+        "CodeUri": ".",
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType": "Zip",
+        "Handler": "TodoApp.Api::TodoApp.Api.AuthorizerFunction_Authorize_Generated::Authorize"
       }
     }
   }

--- a/src/TodoApp.Cdk/AppSyncApiStack.cs
+++ b/src/TodoApp.Cdk/AppSyncApiStack.cs
@@ -174,7 +174,7 @@ namespace TodoApp.CDK
                 new CfnOutput(this, "AuthorizationType", new CfnOutputProps
                 {
                     Value = "Lambda Authorizer",
-                    Description = "Use 'Bearer valid-token' in Authorization header"
+                    Description = "Use 'valid-token' in Authorization header"
                 });
 
                 new CfnOutput(this, "AuthorizerFunctionArn", new CfnOutputProps

--- a/src/TodoApp.Cdk/AppSyncApiStack.cs
+++ b/src/TodoApp.Cdk/AppSyncApiStack.cs
@@ -2,6 +2,7 @@ using Amazon.CDK;
 using Amazon.CDK.AWS.AppSync;
 using Amazon.CDK.AWS.DynamoDB;
 using Amazon.CDK.AWS.Lambda;
+using Amazon.CDK.AWS.IAM;
 using Constructs;
 using System.Collections.Generic;
 using Attribute = Amazon.CDK.AWS.DynamoDB.Attribute;
@@ -30,6 +31,9 @@ namespace TodoApp.CDK
 
         public AppSyncApiStack(Construct scope, string id, IStackProps props = null) : base(scope, id, props)
         {
+            // Check if Lambda authorization is enabled via context
+            var useLambdaAuth = this.Node.TryGetContext("useLambdaAuth")?.ToString() == "true";
+
             // Create DynamoDB Table
             var todoTable = new Table(this, "TodoTable", new TableProps
             {
@@ -39,12 +43,43 @@ namespace TodoApp.CDK
                 RemovalPolicy = RemovalPolicy.DESTROY
             });
 
-            // Create AppSync API
-            var api = new GraphqlApi(this, "TodoApi", new GraphqlApiProps
+            // Create authorization config based on context
+            AuthorizationConfig authConfig;
+            Function authorizerFunction = null;
+
+            if (useLambdaAuth)
             {
-                Name = "dotnet-appsync-todo-api",
-                Definition = Definition.FromFile("src/TodoApp.Cdk/graphql/schema.graphql"),
-                AuthorizationConfig = new AuthorizationConfig
+                // Create Lambda Authorizer Function
+                authorizerFunction = new Function(this, "AppSyncAuthorizerFunction", new FunctionProps
+                {
+                    Runtime = Runtime.DOTNET_8,
+                    Code = Amazon.CDK.AWS.Lambda.Code.FromAsset("src/TodoApp.Api/bin/Release/net8.0/publish"),
+                    Handler = "TodoApp.Api::TodoApp.Api.AuthorizerFunction_Authorize_Generated::Authorize",
+                    MemorySize = 256,
+                    Timeout = Duration.Seconds(30),
+                    Environment = new Dictionary<string, string>
+                    {
+                        { "POWERTOOLS_SERVICE_NAME", "TodoAppAuthorizer" },
+                        { "POWERTOOLS_METRICS_NAMESPACE", "TodoApp" }
+                    }
+                });
+
+                authConfig = new AuthorizationConfig
+                {
+                    DefaultAuthorization = new AuthorizationMode
+                    {
+                        AuthorizationType = AuthorizationType.LAMBDA,
+                        LambdaAuthorizerConfig = new LambdaAuthorizerConfig
+                        {
+                            Handler = authorizerFunction,
+                            ResultsCacheTtl = Duration.Minutes(5)
+                        }
+                    }
+                };
+            }
+            else
+            {
+                authConfig = new AuthorizationConfig
                 {
                     DefaultAuthorization = new AuthorizationMode
                     {
@@ -53,8 +88,16 @@ namespace TodoApp.CDK
                         {
                             Expires = Expiration.After(Duration.Days(30))
                         }
-                    },
-                },
+                    }
+                };
+            }
+
+            // Create AppSync API
+            var api = new GraphqlApi(this, "TodoApi", new GraphqlApiProps
+            {
+                Name = "dotnet-appsync-todo-api",
+                Definition = Definition.FromFile("src/TodoApp.Cdk/graphql/schema.graphql"),
+                AuthorizationConfig = authConfig,
                 XrayEnabled = true
             });
 
@@ -119,16 +162,39 @@ namespace TodoApp.CDK
                 FieldName = "deleteTodo"
             });
 
-            // Output the AppSync API URL and API Key
+            // Output the AppSync API URL
             new CfnOutput(this, "GraphQLAPIURL", new CfnOutputProps
             {
                 Value = api.GraphqlUrl
             });
 
-            new CfnOutput(this, "GraphQLAPIKey", new CfnOutputProps
+            // Conditional outputs based on auth type
+            if (useLambdaAuth)
             {
-                Value = api.ApiKey ?? "No API Key"
-            });
+                new CfnOutput(this, "AuthorizationType", new CfnOutputProps
+                {
+                    Value = "Lambda Authorizer",
+                    Description = "Use 'Bearer valid-token' in Authorization header"
+                });
+
+                new CfnOutput(this, "AuthorizerFunctionArn", new CfnOutputProps
+                {
+                    Value = authorizerFunction!.FunctionArn
+                });
+            }
+            else
+            {
+                new CfnOutput(this, "GraphQLAPIKey", new CfnOutputProps
+                {
+                    Value = api.ApiKey ?? "No API Key"
+                });
+
+                new CfnOutput(this, "AuthorizationType", new CfnOutputProps
+                {
+                    Value = "API Key",
+                    Description = "Use x-api-key header with the API key"
+                });
+            }
         }
     }
 }

--- a/src/TodoApp.Cdk/AppSyncApiStack.cs
+++ b/src/TodoApp.Cdk/AppSyncApiStack.cs
@@ -54,7 +54,7 @@ namespace TodoApp.CDK
                 {
                     Runtime = Runtime.DOTNET_8,
                     Code = Amazon.CDK.AWS.Lambda.Code.FromAsset("src/TodoApp.Api/bin/Release/net8.0/publish"),
-                    Handler = "TodoApp.Api::TodoApp.Api.AuthorizerFunction_Authorize_Generated::Authorize",
+                    Handler = "TodoApp.Api::TodoApp.Api.AuthorizerFunction_CustomLambdaAuthorizerHandler_Generated::CustomLambdaAuthorizerHandler",
                     MemorySize = 256,
                     Timeout = Duration.Seconds(30),
                     Environment = new Dictionary<string, string>


### PR DESCRIPTION
### Added AWS AppSync Lambda Authorizer

Implemented custom Lambda authorizer function that validates Authorization header tokens

Supports role-based access control with "valid-token" (user) and "admin-token" (admin) authentication

Added role-based authorization to delete operation - only admin users can delete todos

Authorizer results are cached for 5 minutes to optimize performance